### PR TITLE
収益管理ダッシュボード機能の実装

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -986,6 +986,10 @@
                 return <PurchaseHistory user={user} onBack={handleBackToDashboard} />;
             }
 
+            if (currentView === 'revenue-dashboard') {
+                return <RevenueDashboard user={user} onBack={handleBackToDashboard} />;
+            }
+
             if (currentView === 'create-article') {
                 return (
                     <ArticleForm
@@ -1029,6 +1033,14 @@
                                     >
                                         記事管理
                                     </button>
+                                    {user.role === 'admin' && (
+                                        <button
+                                            onClick={() => setCurrentView('revenue-dashboard')}
+                                            className="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500"
+                                        >
+                                            収益管理
+                                        </button>
+                                    )}
                                     <button
                                         onClick={handleLogout}
                                         className="text-gray-400 hover:text-red-600 p-2"
@@ -1387,6 +1399,365 @@
                                             </div>
                                         ))}
                                     </div>
+                                </div>
+                            )}
+                        </div>
+                    </main>
+                </div>
+            );
+        };
+
+        // RevenueDashboard Component
+        const RevenueDashboard = ({ user, onBack }) => {
+            const [stats, setStats] = useState(null);
+            const [transactions, setTransactions] = useState([]);
+            const [monthlyRevenue, setMonthlyRevenue] = useState([]);
+            const [articleRevenue, setArticleRevenue] = useState([]);
+            const [isLoading, setIsLoading] = useState(true);
+            const [currentTab, setCurrentTab] = useState('overview');
+            const [pagination, setPagination] = useState({ current_page: 1, total_pages: 1 });
+
+            useEffect(() => {
+                fetchRevenueData();
+            }, []);
+
+            const fetchRevenueData = async () => {
+                try {
+                    setIsLoading(true);
+                    const token = localStorage.getItem('token');
+                    const headers = {
+                        'Authorization': `Bearer ${token}`
+                    };
+
+                    // 統計データ取得
+                    const statsResponse = await axios.get('http://localhost:8000/api/admin/revenue/stats', { headers });
+                    setStats(statsResponse.data);
+
+                    // 取引履歴取得
+                    const transactionsResponse = await axios.get('http://localhost:8000/api/admin/revenue/transactions', { headers });
+                    setTransactions(transactionsResponse.data.transactions);
+                    setPagination(transactionsResponse.data.pagination);
+
+                    // 月別収益取得
+                    const monthlyResponse = await axios.get('http://localhost:8000/api/admin/revenue/monthly', { headers });
+                    setMonthlyRevenue(monthlyResponse.data.monthly_revenue);
+
+                    // 記事別売上取得
+                    const articleResponse = await axios.get('http://localhost:8000/api/admin/revenue/articles', { headers });
+                    setArticleRevenue(articleResponse.data.article_revenue);
+
+                } catch (error) {
+                    console.error('収益データの取得に失敗しました:', error);
+                    if (error.response?.status === 403) {
+                        alert('管理者権限が必要です');
+                        onBack();
+                    }
+                } finally {
+                    setIsLoading(false);
+                }
+            };
+
+            const formatPrice = (price) => {
+                return new Intl.NumberFormat('ja-JP').format(price);
+            };
+
+            const formatDate = (dateString) => {
+                return new Date(dateString).toLocaleDateString('ja-JP');
+            };
+
+            if (isLoading) {
+                return (
+                    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+                        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+                    </div>
+                );
+            }
+
+            return (
+                <div className="min-h-screen bg-gray-100">
+                    <header className="bg-white shadow">
+                        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                            <div className="flex justify-between items-center py-6">
+                                <div className="flex items-center">
+                                    <button
+                                        onClick={onBack}
+                                        className="text-gray-400 hover:text-gray-600 mr-4"
+                                    >
+                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
+                                        </svg>
+                                    </button>
+                                    <h1 className="text-3xl font-bold text-gray-900">収益管理ダッシュボード</h1>
+                                </div>
+                                <div className="flex items-center space-x-4">
+                                    <span className="text-sm text-gray-700">
+                                        {user.username} さん（管理者）
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </header>
+
+                    <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+                        <div className="px-4 py-6 sm:px-0">
+                            {/* タブナビゲーション */}
+                            <div className="mb-6">
+                                <nav className="flex space-x-8">
+                                    {[
+                                        { id: 'overview', name: '概要' },
+                                        { id: 'transactions', name: '取引履歴' },
+                                        { id: 'monthly', name: '月別収益' },
+                                        { id: 'articles', name: '記事別売上' }
+                                    ].map((tab) => (
+                                        <button
+                                            key={tab.id}
+                                            onClick={() => setCurrentTab(tab.id)}
+                                            className={`${
+                                                currentTab === tab.id
+                                                    ? 'border-green-500 text-green-600'
+                                                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                            } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm`}
+                                        >
+                                            {tab.name}
+                                        </button>
+                                    ))}
+                                </nav>
+                            </div>
+
+                            {/* 概要タブ */}
+                            {currentTab === 'overview' && (
+                                <div className="space-y-6">
+                                    {/* 統計カード */}
+                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                                        <div className="bg-white rounded-lg shadow p-6">
+                                            <div className="flex items-center">
+                                                <div className="flex-shrink-0">
+                                                    <div className="w-8 h-8 bg-green-500 rounded-md flex items-center justify-center">
+                                                        <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                                <div className="ml-5 w-0 flex-1">
+                                                    <dl>
+                                                        <dt className="text-sm font-medium text-gray-500 truncate">総売上</dt>
+                                                        <dd className="text-lg font-medium text-gray-900">¥{formatPrice(stats?.stats?.total_revenue || 0)}</dd>
+                                                    </dl>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="bg-white rounded-lg shadow p-6">
+                                            <div className="flex items-center">
+                                                <div className="flex-shrink-0">
+                                                    <div className="w-8 h-8 bg-blue-500 rounded-md flex items-center justify-center">
+                                                        <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                                <div className="ml-5 w-0 flex-1">
+                                                    <dl>
+                                                        <dt className="text-sm font-medium text-gray-500 truncate">今月の売上</dt>
+                                                        <dd className="text-lg font-medium text-gray-900">¥{formatPrice(stats?.stats?.monthly_revenue || 0)}</dd>
+                                                    </dl>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div className="bg-white rounded-lg shadow p-6">
+                                            <div className="flex items-center">
+                                                <div className="flex-shrink-0">
+                                                    <div className="w-8 h-8 bg-purple-500 rounded-md flex items-center justify-center">
+                                                        <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                                <div className="ml-5 w-0 flex-1">
+                                                    <dl>
+                                                        <dt className="text-sm font-medium text-gray-500 truncate">総取引数</dt>
+                                                        <dd className="text-lg font-medium text-gray-900">{stats?.stats?.total_transactions || 0}件</dd>
+                                                    </dl>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    {/* 人気記事TOP5 */}
+                                    <div className="bg-white rounded-lg shadow">
+                                        <div className="px-6 py-4 border-b border-gray-200">
+                                            <h3 className="text-lg font-semibold text-gray-900">人気記事 TOP5</h3>
+                                        </div>
+                                        <div className="divide-y divide-gray-200">
+                                            {stats?.top_articles?.length > 0 ? stats.top_articles.map((article, index) => (
+                                                <div key={index} className="p-6">
+                                                    <div className="flex justify-between items-start">
+                                                        <div className="flex-1">
+                                                            <h4 className="text-md font-medium text-gray-900">{article.title}</h4>
+                                                            <div className="mt-2 flex items-center space-x-4 text-sm text-gray-500">
+                                                                <span>購入数: {article.purchase_count}件</span>
+                                                                <span>売上: ¥{formatPrice(article.revenue || 0)}</span>
+                                                                <span>価格: ¥{formatPrice(article.price)}</span>
+                                                            </div>
+                                                        </div>
+                                                        <div className="ml-4">
+                                                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                                                #{index + 1}
+                                                            </span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            )) : (
+                                                <div className="p-6 text-center text-gray-500">
+                                                    まだ購入データがありません
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* 取引履歴タブ */}
+                            {currentTab === 'transactions' && (
+                                <div className="bg-white rounded-lg shadow overflow-hidden">
+                                    <div className="px-6 py-4 border-b border-gray-200">
+                                        <h3 className="text-lg font-semibold text-gray-900">取引履歴</h3>
+                                    </div>
+                                    <div className="overflow-x-auto">
+                                        <table className="min-w-full divide-y divide-gray-200">
+                                            <thead className="bg-gray-50">
+                                                <tr>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">購入日</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">記事</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">購入者</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">著者</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">金額</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">状態</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody className="bg-white divide-y divide-gray-200">
+                                                {transactions.map((transaction) => (
+                                                    <tr key={transaction.id}>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            {formatDate(transaction.purchase_date)}
+                                                        </td>
+                                                        <td className="px-6 py-4 text-sm text-gray-900">
+                                                            <div className="max-w-xs truncate">{transaction.article_title}</div>
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            {transaction.buyer_username}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            {transaction.author_username}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            ¥{formatPrice(transaction.amount)}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap">
+                                                            <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                                                                transaction.status === 'completed' 
+                                                                    ? 'bg-green-100 text-green-800' 
+                                                                    : 'bg-yellow-100 text-yellow-800'
+                                                            }`}>
+                                                                {transaction.status === 'completed' ? '完了' : transaction.status}
+                                                            </span>
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    {transactions.length === 0 && (
+                                        <div className="text-center py-12">
+                                            <p className="text-gray-500">取引履歴がありません</p>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* 月別収益タブ */}
+                            {currentTab === 'monthly' && (
+                                <div className="bg-white rounded-lg shadow overflow-hidden">
+                                    <div className="px-6 py-4 border-b border-gray-200">
+                                        <h3 className="text-lg font-semibold text-gray-900">月別収益</h3>
+                                    </div>
+                                    <div className="p-6">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                            {monthlyRevenue.map((data, index) => (
+                                                <div key={index} className="border rounded-lg p-4">
+                                                    <div className="text-lg font-semibold text-gray-900">
+                                                        {data.year}年{data.month}月
+                                                    </div>
+                                                    <div className="mt-2">
+                                                        <div className="text-2xl font-bold text-green-600">
+                                                            ¥{formatPrice(data.revenue)}
+                                                        </div>
+                                                        <div className="text-sm text-gray-500">
+                                                            {data.transactions}件の取引
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                        {monthlyRevenue.length === 0 && (
+                                            <div className="text-center py-12">
+                                                <p className="text-gray-500">月別収益データがありません</p>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* 記事別売上タブ */}
+                            {currentTab === 'articles' && (
+                                <div className="bg-white rounded-lg shadow overflow-hidden">
+                                    <div className="px-6 py-4 border-b border-gray-200">
+                                        <h3 className="text-lg font-semibold text-gray-900">記事別売上</h3>
+                                    </div>
+                                    <div className="overflow-x-auto">
+                                        <table className="min-w-full divide-y divide-gray-200">
+                                            <thead className="bg-gray-50">
+                                                <tr>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">記事タイトル</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">著者</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">価格</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">購入数</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">総売上</th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">公開日</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody className="bg-white divide-y divide-gray-200">
+                                                {articleRevenue.map((article) => (
+                                                    <tr key={article.id}>
+                                                        <td className="px-6 py-4 text-sm text-gray-900">
+                                                            <div className="max-w-xs truncate">{article.title}</div>
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            {article.author_username}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            ¥{formatPrice(article.price)}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            {article.purchase_count}件
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-green-600">
+                                                            ¥{formatPrice(article.total_revenue || 0)}
+                                                        </td>
+                                                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                            {formatDate(article.created_at)}
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    {articleRevenue.length === 0 && (
+                                        <div className="text-center py-12">
+                                            <p className="text-gray-500">有料記事がありません</p>
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         </div>


### PR DESCRIPTION
## Summary
- 管理者専用の収益管理ダッシュボードを実装
- 売上統計、取引履歴、月別収益、記事別売上の包括的な管理機能
- 管理者権限による厳格なアクセス制御

## 主な変更点

### バックエンドAPI実装
- **管理者権限チェック**: `requireAdminAuth()` 関数で権限確認
- **GET /api/admin/revenue/stats**: 総売上、今月売上、取引数統計 + 人気記事TOP5
- **GET /api/admin/revenue/transactions**: 全購入取引履歴（ページネーション対応）
- **GET /api/admin/revenue/monthly**: 過去12ヶ月の月別収益データ
- **GET /api/admin/revenue/articles**: 有料記事の売上ランキング

### フロントエンド実装
- **RevenueDashboard コンポーネント**: タブ形式の包括的ダッシュボード
- **概要タブ**: 
  - 統計カード（総売上・今月売上・総取引数）
  - 人気記事TOP5の詳細表示
- **取引履歴タブ**: 
  - 全購入取引の詳細テーブル
  - 購入日、記事、購入者、著者、金額、状態を表示
- **月別収益タブ**: 
  - 過去12ヶ月の収益をカード形式で表示
- **記事別売上タブ**: 
  - 有料記事の売上ランキングテーブル
  - 購入数、総売上、公開日を表示

### UI/UX改善
- レスポンシブデザイン対応
- 直感的なタブナビゲーション
- 3桁区切り価格フォーマット（¥1,000表記）
- 管理者のみ表示される「収益管理」ボタン
- 権限エラー時の適切なハンドリング

### セキュリティ機能
- 管理者権限の厳格なチェック
- 非管理者アクセス時の403エラー返却
- トークンベースの認証確認

## 技術仕様
- SQL クエリの最適化（LEFT JOIN、GROUP BY活用）
- エラーハンドリングとtry-catch実装
- ページネーション対応
- リアルタイムデータ取得

## Test plan
- [ ] 管理者でログインして収益管理ダッシュボードにアクセス
- [ ] 概要タブの統計データ表示確認
- [ ] 取引履歴タブのテーブル表示確認
- [ ] 月別収益タブのカード表示確認
- [ ] 記事別売上タブのランキング表示確認
- [ ] 一般ユーザーでのアクセス制限確認
- [ ] 未ログイン状態でのアクセス制限確認

## MVP対応
**MVP-010**: 収益管理ダッシュボード ✅ **完了**

🤖 Generated with [Claude Code](https://claude.ai/code)